### PR TITLE
Add pragma once to CUDA copy header

### DIFF
--- a/ggml/src/ggml-cuda/cpy.cuh
+++ b/ggml/src/ggml-cuda/cpy.cuh
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "common.cuh"
 
 #define CUDA_CPY_BLOCK_SIZE 64


### PR DESCRIPTION
## Summary
- add a pragma once include guard to ggml CUDA copy header to avoid duplicate default argument declarations during builds

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dfbdf6f5588325964235a4ad24d53f