### PR TITLE
Improve caching in cuda.local Dockerfile for faster local builds

### DIFF
--- a/.devops/cuda.local.Dockerfile
+++ b/.devops/cuda.local.Dockerfile
@@ -29,11 +29,13 @@ WORKDIR /app
 
 COPY . .
 
-RUN --mount=type=cache,target=/root/.cache/ccache \
+# Reuse the CMake build tree so incremental targets only rebuild touched files
+RUN --mount=type=cache,target=/root/.cache/ccache,sharing=locked \
+    --mount=type=cache,target=/app/build,sharing=locked \
     if [ "${CUDA_DOCKER_ARCH}" != "default" ]; then \
     export CMAKE_ARGS="-DCMAKE_CUDA_ARCHITECTURES=${CUDA_DOCKER_ARCH}"; \
     fi && \
-    cmake -B build -DGGML_NATIVE=OFF -DGGML_CUDA=ON -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON -DLLAMA_BUILD_TESTS=OFF ${CMAKE_ARGS} -DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache . && \
+    cmake -S . -B build -DGGML_NATIVE=OFF -DGGML_CUDA=ON -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON -DLLAMA_BUILD_TESTS=OFF ${CMAKE_ARGS} -DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache && \
     cmake --build build --config Release -j$(nproc)
 
 RUN mkdir -p /app/lib && \
@@ -72,7 +74,7 @@ WORKDIR /app
 
 RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock && \
     apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
## Summary
- reuse the CMake build directory via a BuildKit cache mount to speed up iterative builds
- enable locked sharing on ccache and pip caches to avoid cache corruption during parallel builds
- switch to explicit source/build arguments for cmake configuration to work with the cached build tree

## Testing
- not run (Dockerfile change only)


------
https://chatgpt.com/codex/tasks/task_b_68dfe594218c8325a04e02a03ba2f7bc