### PR TITLE
Cache Python requirements earlier in CUDA local Dockerfile

### DIFF
--- a/.devops/cuda.local.Dockerfile
+++ b/.devops/cuda.local.Dockerfile
@@ -66,9 +66,10 @@ COPY --from=build /app/lib/ /app
 ### Full
 FROM base AS full
 
-COPY --from=build /app/full /app
-
 WORKDIR /app
+
+COPY requirements.txt /app/requirements.txt
+COPY requirements /app/requirements
 
 RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -86,6 +87,8 @@ RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
     && rm -rf /tmp/* /var/tmp/* \
     && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
     && find /var/cache -type f -delete
+
+COPY --from=build /app/full /app
 
 
 ENTRYPOINT ["/app/tools.sh"]


### PR DESCRIPTION
## Summary
- copy the requirement manifest and directory into /app before installing dependencies in the CUDA local image
- ensure nested requirement includes resolve by preserving the requirements directory structure

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dfea3e72e083258666f3dfc1938537