### PR TITLE
Fix SINQ row scaling on CUDA

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -191,7 +191,10 @@ static __global__ void sinq_scale_matrix_rows_kernel(
     }
 
     const int64_t index = row * ncols + col;
-    const float scaled = sinq_scale_to_float(data[index]) * scales[col];
+    // Algorithm 1 from the SINQ paper applies the second scale vector along
+    // the output axis (rows). Each element in the row is multiplied by the
+    // corresponding row scale; reference Eq. (6) in https://arxiv.org/abs/2509.22944.
+    const float scaled = sinq_scale_to_float(data[index]) * scales[row];
     data[index] = sinq_scale_from_float<T>(scaled);
 }
 


### PR DESCRIPTION
## Summary
- apply SINQ row scaling along the output axis in the CUDA kernel to match Algorithm 1 / Eq. (6) of the paper

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e00338df0c8325b19f10fd59be096d