### PR TITLE
Fix SINQ CUDA scratch tensor metadata

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -2196,16 +2196,21 @@ static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor
     ggml_tensor src1_sinq = *src1;
     // src1_sinq is a temporary tensor that uses a scratch buffer to hold the
     // column-scaled activations.  Any backend metadata associated with the
-    // original tensor (buffer handles, extra CUDA bookkeeping, etc.) must be
-    // cleared so subsequent CUDA helpers interact only with the explicit device
-    // pointer we manage below.  Leaving the original metadata in place can lead
-    // to helpers reading stale addresses that belong to the weight buffer
-    // instead of our scratch allocation, which prevents the kernel launches
-    // from ever executing and effectively stalls inference.
+    // original tensor (buffer handles, extra CUDA bookkeeping, graph links,
+    // etc.) must be cleared so subsequent CUDA helpers interact only with the
+    // explicit device pointer we manage below.  Leaving the original metadata
+    // in place can lead to helpers reading stale addresses that belong to the
+    // weight buffer instead of our scratch allocation, which prevents the kernel
+    // launches from ever executing and effectively stalls inference.
     src1_sinq.extra     = nullptr;
     src1_sinq.buffer    = nullptr;
     src1_sinq.view_src  = nullptr;
     src1_sinq.view_offs = 0;
+    src1_sinq.op        = GGML_OP_NONE;
+    src1_sinq.flags     = 0;
+    for (auto & src_entry : src1_sinq.src) {
+        src_entry = nullptr;
+    }
     const ggml_tensor * src1_compute = src1;
     ggml_cuda_pool_alloc<float>       sinq_col_dev;
     ggml_cuda_pool_alloc<float>       sinq_row_dev;


### PR DESCRIPTION
## Summary
- clear all graph-related metadata on the temporary SINQ scratch tensor used during CUDA matmul
- prevent stale references from blocking CUDA kernel launches when applying SINQ scaling

## Testing
- not run (requires CUDA hardware)


------
https://chatgpt.com/codex/tasks/task_b_68e03200fa508325be2a25fa9f4cbd2f