### PR TITLE
Fix CUDA graph guard in ggml

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -3400,6 +3400,9 @@ static void evaluate_and_capture_cuda_graph(ggml_backend_cuda_context * cuda_ctx
         } else {
             graph_evaluated_or_captured = true; // ggml graph has been directly evaluated
         }
+#else
+        graph_evaluated_or_captured = true; // CUDA graphs disabled at compile time
+#endif // USE_CUDA_GRAPH
     }
 
 #ifdef USE_CUDA_GRAPH


### PR DESCRIPTION
## Summary
- ensure the CUDA graph capture guard properly handles builds without USE_CUDA_GRAPH
- close the conditional when CUDA graphs are disabled at compile time to avoid infinite loop and preprocessing errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e036cb3110832588cdcc8004563c89