### PR TITLE
Add debug-enabled CUDA local Dockerfile

### DIFF
--- a/.devops/cuda.local.debug.Dockerfile
+++ b/.devops/cuda.local.debug.Dockerfile
@@ -1,0 +1,126 @@
+# syntax=docker/dockerfile:1.6
+
+# This Dockerfile mirrors `.devops/cuda.local.Dockerfile` but configures the
+# build for Debug binaries to aid with diagnosing issues locally. It requires
+# building with Docker BuildKit enabled.
+
+ARG UBUNTU_VERSION=22.04
+# This needs to generally match the container host's environment.
+ARG CUDA_VERSION=12.4.0
+# Target the CUDA build image
+ARG BASE_CUDA_DEV_CONTAINER=nvidia/cuda:${CUDA_VERSION}-devel-ubuntu${UBUNTU_VERSION}
+
+ARG BASE_CUDA_RUN_CONTAINER=nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}
+
+FROM ${BASE_CUDA_DEV_CONTAINER} AS build
+
+# CUDA architecture to build for (defaults to all supported archs)
+ARG CUDA_DOCKER_ARCH=default
+# Allow overriding the build type if needed (defaults to Debug for troubleshooting)
+ARG CMAKE_BUILD_TYPE=Debug
+
+ENV CCACHE_DIR=/root/.cache/ccache
+
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock && \
+    apt-get update && \
+    apt-get install -y build-essential cmake python3 python3-pip git libcurl4-openssl-dev libgomp1 ccache
+
+WORKDIR /app
+
+COPY . .
+
+# Reuse the CMake build tree so incremental targets only rebuild touched files
+RUN --mount=type=cache,target=/root/.cache/ccache,sharing=locked \
+    --mount=type=cache,target=/app/build,sharing=locked \
+    if [ "${CUDA_DOCKER_ARCH}" != "default" ]; then \
+    export CMAKE_ARGS="-DCMAKE_CUDA_ARCHITECTURES=${CUDA_DOCKER_ARCH}"; \
+    fi && \
+    cmake -S . -B build -DGGML_NATIVE=OFF -DGGML_CUDA=ON -DGGML_BACKEND_DL=ON -DGGML_CPU_ALL_VARIANTS=ON -DLLAMA_BUILD_TESTS=OFF \
+    ${CMAKE_ARGS} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_EXE_LINKER_FLAGS=-Wl,--allow-shlib-undefined -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache && \
+    cmake --build build --config ${CMAKE_BUILD_TYPE} -j$(nproc) && \
+    mkdir -p /app/lib && \
+    find build -name "*.so" -exec cp {} /app/lib \; && \
+    mkdir -p /app/full && \
+    cp build/bin/* /app/full && \
+    cp *.py /app/full && \
+    cp -r gguf-py /app/full && \
+    cp -r requirements /app/full && \
+    cp requirements.txt /app/full && \
+    cp .devops/tools.sh /app/full/tools.sh
+
+## Base image
+FROM ${BASE_CUDA_RUN_CONTAINER} AS runtime_base
+
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock && \
+    apt-get update \
+    && apt-get install -y libgomp1 curl \
+    && apt autoremove -y \
+    && apt clean -y \
+    && rm -rf /tmp/* /var/tmp/* \
+    && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
+    && find /var/cache -type f -delete
+
+FROM runtime_base AS python_env
+
+WORKDIR /tmp/pip
+
+COPY requirements.txt ./requirements.txt
+COPY requirements ./requirements
+
+RUN --mount=type=cache,target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    rm -f /var/lib/apt/lists/lock /var/cache/apt/archives/lock && \
+    apt-get update \
+    && apt-get install -y \
+    git \
+    python3 \
+    python3-pip \
+    && python3 -m pip install --upgrade pip setuptools wheel \
+    && python3 -m pip install --break-system-packages -r requirements.txt \
+    && apt autoremove -y \
+    && apt clean -y \
+    && rm -rf /tmp/* /var/tmp/* \
+    && find /var/cache/apt/archives /var/lib/apt/lists -not -name lock -type f -delete \
+    && find /var/cache -type f -delete \
+    && rm -rf /tmp/pip
+
+FROM runtime_base AS base
+
+COPY --from=build /app/lib/ /app
+
+### Full
+FROM python_env AS full
+
+WORKDIR /app
+
+COPY --from=build /app/lib/ /app
+COPY --from=build /app/full /app
+
+ENTRYPOINT ["/app/tools.sh"]
+
+### Light, CLI only
+FROM base AS light
+
+COPY --from=build /app/full/llama-cli /app
+
+WORKDIR /app
+
+ENTRYPOINT [ "/app/llama-cli" ]
+
+### Server, Server only
+FROM base AS server
+
+ENV LLAMA_ARG_HOST=0.0.0.0
+
+COPY --from=build /app/full/llama-server /app
+
+WORKDIR /app
+
+HEALTHCHECK CMD [ "curl", "-f", "http://localhost:8080/health" ]
+
+ENTRYPOINT [ "/app/llama-server" ]


### PR DESCRIPTION
## Summary
- add a CUDA local Dockerfile variant that defaults to Debug builds for troubleshooting
- allow overriding the CMake build type while retaining cache mounts and staging outputs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e0bbc838088325bc24bfe6dd6a01fa