### PR TITLE
Align SINQ quantization with reference implementation

### DIFF
--- a/include/llama.h
+++ b/include/llama.h
@@ -361,8 +361,8 @@ extern "C" {
         bool keep_split;                      // quantize to the same number of shards
         bool use_sinq;                        // enable Sinkhorn-Normalized Quantization preconditioning
         int32_t sinq_iterations;              // number of Sinkhorn normalization iterations
-        float sinq_min_std;                   // minimum allowed standard deviation during normalization
-        float sinq_max_log_delta;             // clamp on log-scale updates per iteration
+        float sinq_min_std;                   // minimum clamp applied to per-axis standard deviations during normalization
+        float sinq_max_log_delta;             // deprecated compatibility field (unused)
         void * imatrix;                       // pointer to importance matrix data
         void * kv_overrides;                  // pointer to vector containing overrides
         void * tensor_types;                  // pointer to vector containing tensor types

--- a/tools/quantize/quantize.cpp
+++ b/tools/quantize/quantize.cpp
@@ -134,7 +134,7 @@ static void usage(const char * executable) {
     printf("  --sinq: enable Sinkhorn-Normalized Quantization preconditioning for 2D weight tensors\n");
     printf("  --sinq-iters N: run N Sinkhorn iterations per tensor (default: %d)\n", llama_model_quantize_default_params().sinq_iterations);
     printf("  --sinq-min-std F: clamp per-axis standard deviations to be at least F during normalization (default: %.1e)\n", llama_model_quantize_default_params().sinq_min_std);
-    printf("  --sinq-max-log-delta F: limit per-iteration log-scale updates to +-F (default: %.1f)\n", llama_model_quantize_default_params().sinq_max_log_delta);
+    printf("  --sinq-max-log-delta F: deprecated compatibility flag (default: %.1f)\n", llama_model_quantize_default_params().sinq_max_log_delta);
     printf("  --prune-layers L0,L1,L2...comma-separated list of layer numbers to prune from the model\n");
     printf("      Advanced option to remove all tensors from the given layers\n");
     printf("  --keep-split: will generate quantized model in the same shards as input\n");


### PR DESCRIPTION
## Summary
- port the SINQ normalization routine to match the reference sinkhorn_log implementation from huawei-csl/SINQ, including best-scale tracking and gating behaviour
- update the default SINQ iteration count and minimum standard deviation clamp to mirror the reference settings and clarify related CLI/help text

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e0cc08e18483259ce2a52424eda8fd