### PR TITLE
Fix SINQ CUDA scratch tensor metadata

### DIFF
--- a/ggml/src/ggml-cuda/ggml-cuda.cu
+++ b/ggml/src/ggml-cuda/ggml-cuda.cu
@@ -58,6 +58,7 @@
 
 #include <array>
 #include <atomic>
+#include <cstring>
 #include <charconv>
 #include <cinttypes>
 #include <condition_variable>
@@ -2208,7 +2209,13 @@ static void ggml_cuda_mul_mat(ggml_backend_cuda_context & ctx, const ggml_tensor
 #endif
     }
 
-    ggml_tensor src1_sinq = *src1;
+    ggml_tensor src1_sinq = {};
+    src1_sinq.type   = src1->type;
+    src1_sinq.buffer = src1->buffer;
+    memcpy(src1_sinq.ne, src1->ne, sizeof(src1_sinq.ne));
+    memcpy(src1_sinq.nb, src1->nb, sizeof(src1_sinq.nb));
+    src1_sinq.data = src1->data;
+    memcpy(src1_sinq.name, src1->name, sizeof(src1_sinq.name));
     // src1_sinq is a temporary tensor that uses a scratch buffer to hold the
     // column-scaled activations.  Any backend metadata associated with the
     // original tensor (buffer handles, extra CUDA bookkeeping, graph links,


### PR DESCRIPTION
## Summary
- zero-initialize the temporary SINQ scratch tensor on CUDA and copy only the required fields before clearing runtime metadata to prevent stale bookkeeping
- include `<cstring>` for the new memcpy usage

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e0d26e83e083258104472a065a24ad