### PR TITLE
Handle SINQ warmup on CUDA

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -689,6 +689,12 @@ void llama_context::set_warmup(bool value) {
     LLAMA_LOG_DEBUG("%s: value = %d\n", __func__, value);
 
     cparams.warmup = value;
+
+#if defined(GGML_USE_CUDA)
+    if (model.has_sinq_scales()) {
+        model.set_cuda_sinq_backend_enabled(!value);
+    }
+#endif
 }
 
 void llama_context::set_adapter_lora(

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -496,6 +496,12 @@ struct llama_model {
         return get_sinq_scales(std::string(tensor_name));
     }
 
+    bool has_sinq_scales() const;
+#if defined(GGML_USE_CUDA)
+    void set_cuda_sinq_backend_enabled(bool enabled) const;
+    bool cuda_sinq_backend_enabled() const;
+#endif
+
     ggml_tensor * mul_mat_with_sinq(ggml_context * ctx, ggml_tensor * weight, ggml_tensor * input) const;
     ggml_tensor * mul_mat_id_with_sinq(ggml_context * ctx, ggml_tensor * weight, ggml_tensor * input, ggml_tensor * ids) const;
 


### PR DESCRIPTION
## Summary
- allow the SINQ CUDA backend to be toggled at runtime and register or clear scales accordingly
- fall back to graph-level SINQ scaling during warmup so llama-server can finish initialization before re-enabling GPU scaling
- guard matmul helpers so they skip redundant scaling when the CUDA backend is active

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e0d9780bb8832593bd43c7a079b21c