### PR TITLE
Fix offline pip install in CUDA full image

### DIFF
--- a/.devops/cuda.Dockerfile
+++ b/.devops/cuda.Dockerfile
@@ -68,7 +68,8 @@ RUN apt-get update \
     python3 \
     python3-pip \
     && pip install --upgrade pip setuptools wheel \
-    && pip install --break-system-packages --no-index --find-links /wheels -r requirements.txt \
+    && pip install --break-system-packages --no-index --find-links /wheels \
+        --no-build-isolation -r requirements.txt \
     && apt autoremove -y \
     && apt clean -y \
     && rm -rf /tmp/* /var/tmp/* \


### PR DESCRIPTION
## Summary
- disable pip build isolation when installing requirements in the CUDA full image
- allow the offline install to reuse the setuptools version already upgraded in the image

## Testing
- `docker build -t local/llama.cpp:full-cuda-sinq --target full -f .devops/cuda.Dockerfile .` *(fails: docker unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e0f554228883259e576e545510294c