### PR TITLE
Fix SINQ metadata lookup for long tensor names

### DIFF
--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -408,6 +408,7 @@ struct llama_model {
         std::vector<float> row;
         std::vector<float> col;
         float imbalance = 1.0f;
+        std::string source_name;
     };
 
     // for classifier models


### PR DESCRIPTION
## Summary
- store SINQ scale metadata under the truncated tensor names that ggml uses internally so long names still resolve
- preserve the original tensor name for diagnostics and reuse it when validating shapes or emitting warnings
- use the preserved name when logging CPU fallback mismatches for mul_mat and mul_mat_id

## Testing
- cmake --build build --target llama -j4
- ctest --test-dir build --output-on-failure # fails: optional unit test binaries were not built in this partial build

------
https://chatgpt.com/codex/tasks/task_b_68e1130f1c7483259bce9b82a44e5ee0