### PR TITLE
Fix SINQ scaling when building graphs on no-alloc contexts

### DIFF
--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -427,7 +427,11 @@ ggml_tensor * llama_model::mul_mat_with_sinq(ggml_context * ctx, ggml_tensor * w
     ggml_tensor * scaled_input = input;
     if (!col_scales->empty()) {
         ggml_tensor * col = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, col_scales->size());
-        std::memcpy(col->data, col_scales->data(), col_scales->size() * sizeof(float));
+        if (col->data != nullptr) {
+            std::memcpy(col->data, col_scales->data(), col_scales->size() * sizeof(float));
+        } else {
+            col->data = const_cast<float *>(col_scales->data());
+        }
         std::string col_name = std::string(weight_name) + ".sinq_col";
         ggml_set_name(col, col_name.c_str());
         scaled_input = ggml_mul(ctx, scaled_input, ggml_repeat(ctx, col, scaled_input));
@@ -439,7 +443,11 @@ ggml_tensor * llama_model::mul_mat_with_sinq(ggml_context * ctx, ggml_tensor * w
 
     if (!row_scales->empty()) {
         ggml_tensor * row = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, row_scales->size());
-        std::memcpy(row->data, row_scales->data(), row_scales->size() * sizeof(float));
+        if (row->data != nullptr) {
+            std::memcpy(row->data, row_scales->data(), row_scales->size() * sizeof(float));
+        } else {
+            row->data = const_cast<float *>(row_scales->data());
+        }
         std::string row_name = std::string(weight_name) + ".sinq_row";
         ggml_set_name(row, row_name.c_str());
         result = ggml_mul(ctx, result, ggml_repeat(ctx, row, result));
@@ -502,7 +510,11 @@ ggml_tensor * llama_model::mul_mat_id_with_sinq(ggml_context * ctx, ggml_tensor 
     ggml_tensor * scaled_input = input;
     if (!col_scales->empty()) {
         ggml_tensor * col = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, col_scales->size());
-        std::memcpy(col->data, col_scales->data(), col_scales->size() * sizeof(float));
+        if (col->data != nullptr) {
+            std::memcpy(col->data, col_scales->data(), col_scales->size() * sizeof(float));
+        } else {
+            col->data = const_cast<float *>(col_scales->data());
+        }
         std::string col_name = std::string(weight_name) + ".sinq_col";
         ggml_set_name(col, col_name.c_str());
         scaled_input = ggml_mul(ctx, scaled_input, ggml_repeat(ctx, col, scaled_input));
@@ -515,7 +527,11 @@ ggml_tensor * llama_model::mul_mat_id_with_sinq(ggml_context * ctx, ggml_tensor 
 
     if (!row_scales->empty()) {
         ggml_tensor * row = ggml_new_tensor_1d(ctx, GGML_TYPE_F32, row_scales->size());
-        std::memcpy(row->data, row_scales->data(), row_scales->size() * sizeof(float));
+        if (row->data != nullptr) {
+            std::memcpy(row->data, row_scales->data(), row_scales->size() * sizeof(float));
+        } else {
+            row->data = const_cast<float *>(row_scales->data());
+        }
         std::string row_name = std::string(weight_name) + ".sinq_row";
         ggml_set_name(row, row_name.c_str());
         result = ggml_mul(ctx, result, ggml_repeat(ctx, row, result));


### PR DESCRIPTION
## Summary
- ensure SINQ scaling tensors reuse the persistent SINQ scale data when the temporary graph context is created with `no_alloc`
- avoid writing into null tensor buffers by falling back to direct pointers for column and row scales

## Testing
- cmake --build build -j4 --target llama

------
https://chatgpt.com/codex/tasks/task_b_68e1188487bc83258db48eaa9d0337a5