### PR TITLE
Fix SINQ scaling for CPU get_rows

### DIFF
--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -642,6 +642,11 @@ ggml_tensor * llm_graph_context::build_lora_mm_id(
     return res;
 }
 
+ggml_tensor * llm_graph_context::get_rows_with_sinq(ggml_tensor * tensor, ggml_tensor * ids) const {
+    return model_ptr ? model_ptr->get_rows_with_sinq(ctx0, tensor, ids)
+                     : ggml_get_rows(ctx0, tensor, ids);
+}
+
 ggml_tensor * llm_graph_context::build_norm(
          ggml_tensor * cur,
          ggml_tensor * mw,
@@ -1101,7 +1106,7 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
         ggml_set_input(inp->tokens);
         res->t_tokens = inp->tokens;
 
-        cur = ggml_get_rows(ctx0, tok_embd, inp->tokens);
+        cur = get_rows_with_sinq(tok_embd, inp->tokens);
 
         // apply lora for embedding tokens if needed
         for (const auto & lora : *loras) {

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -613,6 +613,8 @@ struct llm_graph_context {
               ggml_tensor * cur, // ggml_tensor * b
               ggml_tensor * ids) const;
 
+    ggml_tensor * get_rows_with_sinq(ggml_tensor * tensor, ggml_tensor * ids) const;
+
     ggml_tensor * build_norm(
              ggml_tensor * cur,
              ggml_tensor * mw,

--- a/src/llama-model.h
+++ b/src/llama-model.h
@@ -505,6 +505,7 @@ struct llama_model {
 
     ggml_tensor * mul_mat_with_sinq(ggml_context * ctx, ggml_tensor * weight, ggml_tensor * input) const;
     ggml_tensor * mul_mat_id_with_sinq(ggml_context * ctx, ggml_tensor * weight, ggml_tensor * input, ggml_tensor * ids) const;
+    ggml_tensor * get_rows_with_sinq(ggml_context * ctx, ggml_tensor * weight, ggml_tensor * ids) const;
 
     float get_rope_freq_base (const llama_cparams & cparams, int il) const;
     float get_rope_freq_scale(const llama_cparams & cparams, int il) const;
@@ -518,6 +519,12 @@ struct llama_model {
     // TODO: move this to new llm_arch_model_i interface
     ggml_cgraph * build_graph(const llm_graph_params & params) const;
 
+    friend void llama_model_test_set_sinq_scales(
+        llama_model & model,
+        const char * tensor_name,
+        const std::vector<float> & row,
+        const std::vector<float> & col);
+
 private:
     struct impl;
     std::unique_ptr<impl> pimpl;
@@ -528,3 +535,9 @@ const char * llm_type_name(llm_type type);
 // For internal test use
 // TODO: remove
 const std::vector<std::pair<std::string, ggml_tensor *>> & llama_internal_get_tensor_map(const llama_model * model);
+
+void llama_model_test_set_sinq_scales(
+        llama_model & model,
+        const char * tensor_name,
+        const std::vector<float> & row,
+        const std::vector<float> & col);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -184,6 +184,7 @@ llama_build_and_test(test-chat-template.cpp)
 llama_build_and_test(test-json-partial.cpp)
 llama_build_and_test(test-log.cpp)
 llama_build_and_test(test-regex-partial.cpp)
+llama_build_and_test(test-sinq-get-rows.cpp)
 
 if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "s390x")
     llama_build_and_test(test-thread-safety.cpp ARGS -hf ggml-org/models -hff tinyllamas/stories15M-q4_0.gguf -ngl 99 -p "The meaning of life is" -n 128 -c 256 -ub 32 -np 4 -t 2)

--- a/tests/test-sinq-get-rows.cpp
+++ b/tests/test-sinq-get-rows.cpp
@@ -1,0 +1,84 @@
+#include "../src/llama-model.h"
+
+#include <ggml.h>
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+int main() {
+    llama_model_params params = llama_model_default_params();
+    llama_model model(params);
+
+    const int nrows = 4;
+    const int ncols = 3;
+
+    const std::vector<float> row_scale = {1.5f, 0.5f, 2.0f, 1.2f};
+    const std::vector<float> col_scale = {0.8f, 1.3f, 0.6f};
+
+    std::vector<float> original = {
+        1.0f,  2.0f,  3.0f,
+        4.0f,  5.0f,  6.0f,
+        7.0f,  8.0f,  9.0f,
+       10.0f, 11.0f, 12.0f,
+    };
+
+    std::vector<float> normalized(nrows * ncols);
+    for (int r = 0; r < nrows; ++r) {
+        for (int c = 0; c < ncols; ++c) {
+            normalized[r * ncols + c] = original[r * ncols + c] / (row_scale[r] * col_scale[c]);
+        }
+    }
+
+    llama_model_test_set_sinq_scales(model, "weight", row_scale, col_scale);
+
+    const size_t mem_size = 1u << 18;
+    std::vector<uint8_t> buffer(mem_size);
+    ggml_init_params init_params = {};
+    init_params.mem_size   = buffer.size();
+    init_params.mem_buffer = buffer.data();
+    ggml_context * ctx = ggml_init(init_params);
+    assert(ctx != nullptr);
+
+    ggml_tensor * weight = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, ncols, nrows);
+    ggml_set_name(weight, "weight");
+    std::memcpy(weight->data, normalized.data(), normalized.size() * sizeof(float));
+
+    const int n_ids = 3;
+    ggml_tensor * ids = ggml_new_tensor_1d(ctx, GGML_TYPE_I32, n_ids);
+    ggml_set_name(ids, "ids");
+    auto * ids_data = static_cast<int32_t *>(ids->data);
+    ids_data[0] = 2;
+    ids_data[1] = 0;
+    ids_data[2] = 3;
+    ggml_set_input(ids);
+
+    ggml_tensor * result = model.get_rows_with_sinq(ctx, weight, ids);
+
+    ggml_cgraph * gf = ggml_new_graph(ctx);
+    ggml_build_forward_expand(gf, result);
+    ggml_graph_compute_with_ctx(ctx, gf, 1);
+
+    auto get_value = [&](int token, int col) {
+        return *reinterpret_cast<float *>(
+            static_cast<char *>(result->data) + token * result->nb[1] + col * result->nb[0]);
+    };
+
+    const float tol = 1e-6f;
+    for (int t = 0; t < n_ids; ++t) {
+        int row_index = ids_data[t];
+        for (int c = 0; c < ncols; ++c) {
+            float expected = original[row_index * ncols + c];
+            float actual   = get_value(t, c);
+            if (std::fabs(expected - actual) > tol) {
+                ggml_free(ctx);
+                return 1;
+            }
+        }
+    }
+
+    ggml_free(ctx);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- apply SINQ scaling when gathering model rows on the CPU
- add a helper to reuse the logic across graph builders
- cover the regression with a dedicated unit test

## Testing
- ctest --test-dir build -R test-sinq-get-rows -V

------
https://chatgpt.com/codex/tasks/task_b_68e1205f9f8483258f2f2071df755481